### PR TITLE
feat: telemetry label utility

### DIFF
--- a/client/app/constants/telemetryLabels.ts
+++ b/client/app/constants/telemetryLabels.ts
@@ -1,0 +1,68 @@
+export const TELEMETRY_LABELS: Record<string, string> = {
+    // --- EVA (shared between EVA1 and EVA2) ---
+    primary_battery_level: "Primary Battery",
+    secondary_battery_level: "Secondary Battery",
+    battery_level: "Battery Level",
+    oxy_pri_storage: "Primary O2 Storage",
+    oxy_sec_storage: "Secondary O2 Storage",
+    oxy_pri_pressure: "Primary O2 Pressure",
+    oxy_sec_pressure: "Secondary O2 Pressure",
+    suit_pressure_oxy: "O2 Suit Pressure",
+    suit_pressure_co2: "CO2 Suit Pressure",
+    suit_pressure_other: "Other Suit Pressure",
+    suit_pressure_total: "Total Suit Pressure",
+    helmet_pressure_co2: "Helmet CO2 Pressure",
+    fan_pri_rpm: "Fan 1",
+    fan_sec_rpm: "Fan 2",
+    scrubber_a_co2_storage: "CO2 Scrubber A",
+    scrubber_b_co2_storage: "CO2 Scrubber B",
+    temperature: "Body Temperature",
+    coolant_storage: "Coolant Storage",
+    coolant_gas_pressure: "Coolant Gas Pressure",
+    coolant_liquid_pressure: "Coolant Liquid Pressure",
+    heart_rate: "Heart Rate",
+    oxy_consumption: "O2 Consumption",
+    co2_production: "CO2 Production",
+    eva_elapsed_time: "EVA Elapsed Time",
+
+    // --- Rover (PrTelemetry) ---
+    oxygen_storage: "Oxygen Storage",
+    oxygen_pressure: "O2 Pressure",
+    oxygen_tank: "Oxygen Tank",
+    cabin_pressure: "Cabin Pressure",
+    cabin_temperature: "Cabin Temperature",
+    cabin_temperature_target: "Target Cabin Temperature",
+    external_temp: "External Temperature",
+    coolant_pressure: "Coolant Pressure",
+    cabin_heating: "Cabin Heating",
+    cabin_cooling: "Cabin Cooling",
+    lights_on: "Lights",
+    brakes: "Brakes",
+    throttle: "Throttle",
+    steering: "Steering",
+    rover_pos_x: "Rover X Position",
+    rover_pos_y: "Rover Y Position",
+    rover_pos_z: "Rover Z Position",
+    heading: "Heading",
+    pitch: "Pitch",
+    roll: "Roll",
+    distance_traveled: "Distance Traveled",
+    distance_from_base: "Distance from Base",
+    speed: "Speed",
+    sunlight: "Sunlight",
+    surface_incline: "Surface Incline",
+    sim_running: "Simulation Running",
+    dust_connected: "Dust Connected",
+    rover_elapsed_time: "Rover Elapsed Time",
+};
+
+export function getTelemetryLabel(field: string): string {
+    if (!field) return "";
+    return (
+        TELEMETRY_LABELS[field] ??
+        field // fallback
+            .split("_")
+            .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+            .join(" ")
+    );
+}

--- a/client/app/features/task-board/telemetry.tsx
+++ b/client/app/features/task-board/telemetry.tsx
@@ -3,6 +3,8 @@ import { useTelemetry } from "~/hooks/useTelemetry";
 import { useEstimates } from "./hooks/useEstimates";
 
 import { EVA_LIMITS, ROVER_LIMITS } from "~/constants/telemetryLimits";
+import { getTelemetryLabel } from "~/constants/telemetryLabels";
+
 import Battery from "~/components/ui/Battery";
 import Card from "~/components/ui/Card";
 import CO2 from "~/components/ui/CO2";
@@ -47,7 +49,7 @@ const FIELD_LABELS: Record<string, string> = {
 };
 
 function warningMessage(w: Warning): string {
-    return FIELD_LABELS[w.field] ?? `${w.field.replace(/_/g, " ")} is out of range.`;
+    return FIELD_LABELS[w.field] ?? `${getTelemetryLabel(w.field)} is out of range.`;
 }
 
 function formatRemaining(s: number | null): string {
@@ -281,11 +283,11 @@ export default function Telemetry() {
                                 <Pressure
                                     value={rover.cabin_pressure}
                                     {...ROVER_LIMITS.cabin_pressure}
-                                    label="Cabin Pressure"
+                                    label={getTelemetryLabel("cabin_pressure")}
                                 />
                                 <Graph
                                     value={rover.oxygen_pressure}
-                                    label="O2 Pressure"
+                                    label={getTelemetryLabel("oxygen_pressure")}
                                     unit=" psi"
                                     min={ROVER_LIMITS.oxygen_pressure.min}
                                     max={ROVER_LIMITS.oxygen_pressure.max}
@@ -320,8 +322,14 @@ export default function Telemetry() {
                                 />
                                 <Fans
                                     fans={[
-                                        { label: "Fan 1", rpm: rover.fan_pri_rpm ?? 0 },
-                                        { label: "Fan 2", rpm: rover.fan_sec_rpm ?? 0 },
+                                        {
+                                            label: getTelemetryLabel("fan_pri_rpm"),
+                                            rpm: rover.fan_pri_rpm ?? 0,
+                                        },
+                                        {
+                                            label: getTelemetryLabel("fan_sec_rpm"),
+                                            rpm: rover.fan_sec_rpm ?? 0,
+                                        },
                                     ]}
                                     fanWarnings={[
                                         w("rover", "fan_pri_rpm"),
@@ -419,7 +427,7 @@ export default function Telemetry() {
                             <Pressure
                                 value={eva1.suit_pressure_total}
                                 {...EVA_LIMITS.suit_pressure_total}
-                                label="Total Suit Pressure"
+                                label={getTelemetryLabel("suit_pressure_total")}
                             />
                             <div style={{ height: "34px" }} />
                             <Graph


### PR DESCRIPTION
## Summary

This PR resolves #35 by adding a helper (`client/app/constants/telemetryLimits.ts`) that the frontend can use to resolve "code-like" telemetry labels (e.g., `oxy_pri_pressure`) to readable labels (`Primary O2 Pressure`). 

## Related Issue

Closes #35

## What Changed

See `client/app/constants/telemetryLimits.ts`
## How to Test

<!-- Steps to verify the changes work as expected -->

I visually checked that labels were replaced properly in the telemetry dashboard.

## Deployment Notes

<!-- Note any deployment requirements this PR introduces -->
<!-- Leave N/A if none -->
N/A

## Checklist

- [x] PR title follows naming convention (`type: short description`)
- [x] Rebased off of latest `main` before opening PR
- [x] Ran `make format`
- [x] No unintended files or changes included
- [x] PR is ready for admin review
