### PR TITLE
fix: two-O2-tanks

### DIFF
--- a/client/app/components/ui/Oxygen.tsx
+++ b/client/app/components/ui/Oxygen.tsx
@@ -1,37 +1,98 @@
-import { CX, CY, BG_PATH, FILL_PATH, TICK_PATHS, gaugePoint } from "~/components/ui/gaugeGeometry";
+import { CX, CY, R, BG_PATH, FILL_PATH, TICK_PATHS, gaugePoint } from "~/components/ui/gaugeGeometry";
 
-// Outer ring — same angular geometry as EVACoolant, scaled up (182×143)
 const OUTER_PATH =
     "M163.465 138.744C172.116 125.754 177.096 110.679 177.881 95.1055C178.666 79.5316 175.226 64.0347 167.925 50.2453C160.623 36.4559 149.73 24.884 136.39 16.7471C123.051 8.61024 107.758 4.20927 92.122 4.00728C76.4859 3.80529 61.0843 7.80977 47.5378 15.5993C33.9912 23.3889 22.8006 34.6755 15.1435 48.2717C7.48628 61.8678 3.64566 77.2707 4.0257 92.8597C4.40575 108.449 8.99241 123.647 17.3031 136.856";
 
-// Center of the outer arc in the 182×143 coordinate space
 const OCX = 90.97;
 const OCY = 90.85;
 
-// Inner gauge rendered at 1.1× scale — offset keeps arc centers aligned
+// Normal mode: inner gauge slightly larger than its base 137×122 viewBox
 const INNER_SCALE = 1.1;
 const INNER_W = 137 * INNER_SCALE; // 150.7
 const INNER_H = 122 * INNER_SCALE; // 134.2
 const INNER_LEFT = OCX - CX * INNER_SCALE; // ≈ 23.73
 const INNER_TOP = OCY - CY * INNER_SCALE;  // ≈ 21.81
 
+// Radius of OUTER_PATH arc in the 182×143 coordinate space
+const R_OUTER = 86.87;
+
+// Swap mode: gauge at outer arc radius, centered at OCX/OCY (div overflows container,
+// but arc content stays within the 182×143 bounds since the arc itself fits)
+const OUTER_SCALE = R_OUTER / R;
+const OUTER_W = 137 * OUTER_SCALE;
+const OUTER_H = 122 * OUTER_SCALE;
+const OUTER_LEFT = OCX - CX * OUTER_SCALE;
+const OUTER_TOP = OCY - CY * OUTER_SCALE;
+
+// Swap mode: static ring shrunk so its arc radius matches the inner gauge arc,
+// centered at OCX/OCY (uniform scale → no aspect-ratio distortion)
+const INNER_RING_SCALE = (R * INNER_SCALE) / R_OUTER;
+const INNER_RING_W = 182 * INNER_RING_SCALE;
+const INNER_RING_H = 143 * INNER_RING_SCALE;
+const INNER_RING_LEFT = OCX * (1 - INNER_RING_SCALE);
+const INNER_RING_TOP = OCY * (1 - INNER_RING_SCALE);
+
 interface OxygenProps {
-    level: number; // 0–100
-    tankLabel?: string;
+    levelTank1: number; // 0–100
+    levelTank2: number; // 0–100
+    primaryActive?: boolean; // true (default) = tank 1, false = tank 2
     remaining?: string;
 }
 
 export default function Oxygen({
-    level,
-    tankLabel = "Tank 1",
+    levelTank1,
+    levelTank2,
+    primaryActive,
     remaining = "8:00:00 Remaining",
 }: OxygenProps) {
-    const clamped = Math.min(100, Math.max(0, level));
+    const clampedTank1 = Math.min(100, Math.max(0, levelTank1));
+    const clampedTank2 = Math.min(100, Math.max(0, levelTank2));
+    const tank1Empty = primaryActive === false;
+    const clamped = tank1Empty ? clampedTank2 : clampedTank1;
     const isLow = clamped < 50;
     const fillColor = isLow ? "#F59095" : "#E9FFF6";
     const fillOpacity = isLow ? 0.5 : 0.415;
     const pct = clamped / 100;
     const indicator = gaugePoint(pct);
+
+    const gaugeArc = (w: number, h: number) => (
+        <svg viewBox="0 0 137 122" width={w} height={h} style={{ overflow: "visible" }}>
+            <path d={BG_PATH} fill="none" stroke="#4F4F59" strokeWidth="12" strokeLinecap="round" />
+            <path
+                d={FILL_PATH}
+                fill="none"
+                stroke={fillColor}
+                strokeWidth="12"
+                strokeLinecap="round"
+                pathLength="1"
+                strokeDasharray="1"
+                strokeDashoffset={1 - pct}
+                opacity={fillOpacity}
+            />
+            {TICK_PATHS.map((d) => (
+                <path key={d} d={d} stroke="#7B7B84" strokeWidth="3" strokeLinecap="round" />
+            ))}
+            <circle cx={indicator.x} cy={indicator.y} r={5} fill="white" />
+        </svg>
+    );
+
+    const staticRing = (w: number, h: number, top: number, left: number) => (
+        <svg
+            viewBox="0 0 182 143"
+            width={w}
+            height={h}
+            style={{ position: "absolute", top, left }}
+        >
+            <path
+                d={OUTER_PATH}
+                fill="none"
+                stroke={isLow ? "#9C8080" : "#4F4F59"}
+                strokeWidth="8"
+                strokeLinecap="round"
+                opacity={isLow ? 0.35 : 1}
+            />
+        </svg>
+    );
 
     return (
         <div
@@ -49,69 +110,27 @@ export default function Oxygen({
         >
             {/* Gauge area */}
             <div style={{ position: "relative", width: 182, height: 143 }}>
-                {/* Outer background arc */}
-                <svg
-                    viewBox="0 0 182 143"
-                    width="182"
-                    height="143"
-                    style={{ position: "absolute", top: 0, left: 0 }}
-                >
-                    <path
-                        d={OUTER_PATH}
-                        fill="none"
-                        stroke={isLow ? "#9C8080" : "#4F4F59"}
-                        strokeWidth="8"
-                        strokeLinecap="round"
-                        opacity={isLow ? 0.35 : 1}
-                    />
-                </svg>
+                {tank1Empty ? (
+                    <>
+                        {/* Tank 2 active: gauge at outer arc position */}
+                        <div style={{ position: "absolute", top: OUTER_TOP, left: OUTER_LEFT }}>
+                            {gaugeArc(OUTER_W, OUTER_H)}
+                        </div>
 
-                {/* Inner EVACoolant gauge */}
-                <div
-                    style={{
-                        position: "absolute",
-                        top: INNER_TOP,
-                        left: INNER_LEFT,
-                        width: INNER_W,
-                        height: INNER_H,
-                    }}
-                >
-                    <svg
-                        viewBox="0 0 137 122"
-                        width={INNER_W}
-                        height={INNER_H}
-                        style={{ overflow: "visible" }}
-                    >
-                        <path
-                            d={BG_PATH}
-                            fill="none"
-                            stroke="#4F4F59"
-                            strokeWidth="12"
-                            strokeLinecap="round"
-                        />
-                        <path
-                            d={FILL_PATH}
-                            fill="none"
-                            stroke={fillColor}
-                            strokeWidth="12"
-                            strokeLinecap="round"
-                            pathLength="1"
-                            strokeDasharray="1"
-                            strokeDashoffset={1 - pct}
-                            opacity={fillOpacity}
-                        />
-                        {TICK_PATHS.map((d) => (
-                            <path
-                                key={d}
-                                d={d}
-                                stroke="#7B7B84"
-                                strokeWidth="3"
-                                strokeLinecap="round"
-                            />
-                        ))}
-                        <circle cx={indicator.x} cy={indicator.y} r={5} fill="white" />
-                    </svg>
-                </div>
+                        {/* Static ring shrunk to inner gauge position */}
+                        {staticRing(INNER_RING_W, INNER_RING_H, INNER_RING_TOP, INNER_RING_LEFT)}
+                    </>
+                ) : (
+                    <>
+                        {/* Tank 1 active: static ring at outer position */}
+                        {staticRing(182, 143, 0, 0)}
+
+                        {/* Gauge at inner position */}
+                        <div style={{ position: "absolute", top: INNER_TOP, left: INNER_LEFT }}>
+                            {gaugeArc(INNER_W, INNER_H)}
+                        </div>
+                    </>
+                )}
 
                 {/* Text centered at outer arc center */}
                 <div
@@ -146,7 +165,7 @@ export default function Oxygen({
                             letterSpacing: "0.18px",
                         }}
                     >
-                        {tankLabel}
+                        {tank1Empty ? "Tank 2" : "Tank 1"}
                     </span>
                 </div>
             </div>
@@ -171,30 +190,9 @@ export default function Oxygen({
                         }}
                     >
                         <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                            <rect
-                                x="8"
-                                y="4"
-                                width="8"
-                                height="16"
-                                rx="3"
-                                fill="#c5c9d2"
-                                opacity="0.28"
-                            />
-                            <rect
-                                x="10"
-                                y="2"
-                                width="4"
-                                height="4"
-                                rx="1"
-                                fill="#c5c9d2"
-                                opacity="0.28"
-                            />
-                            <path
-                                d="M10 9H14M10 13H14"
-                                stroke="#9de4ce"
-                                strokeWidth="1.5"
-                                strokeLinecap="round"
-                            />
+                            <rect x="8" y="4" width="8" height="16" rx="3" fill="#c5c9d2" opacity="0.28" />
+                            <rect x="10" y="2" width="4" height="4" rx="1" fill="#c5c9d2" opacity="0.28" />
+                            <path d="M10 9H14M10 13H14" stroke="#9de4ce" strokeWidth="1.5" strokeLinecap="round" />
                         </svg>
                     </div>
                     <span

--- a/client/app/features/task-board/telemetry.tsx
+++ b/client/app/features/task-board/telemetry.tsx
@@ -186,8 +186,8 @@ export default function Telemetry() {
                                 }}
                             >
                                 <Oxygen
-                                    level={rover.oxygen_storage ?? 0}
-                                    tankLabel="Tank 1"
+                                    levelTank1={rover.oxygen_storage ?? 0}
+                                    levelTank2={0}
                                     remaining={formatRemaining(
                                         estimates.rover_oxygen_time_remaining_s,
                                     )}
@@ -332,10 +332,13 @@ export default function Telemetry() {
                                 }}
                             >
                                 <Oxygen
-                                    level={eva1.oxy_pri_storage ?? 0}
-                                    tankLabel="Tank 1"
+                                    levelTank1={eva1.oxy_pri_storage ?? 0}
+                                    levelTank2={eva1.oxy_sec_storage ?? 0}
+                                    primaryActive={snapshot.eva.dcu.eva1.oxy}
                                     remaining={formatRemaining(
-                                        estimates.eva_oxygen_time_remaining_s,
+                                        snapshot.eva.dcu.eva1.oxy
+                                            ? estimates.eva_oxygen_time_remaining_s
+                                            : (eva1.oxy_sec_storage ?? 0) / 0.1,
                                     )}
                                 />
                             </div>


### PR DESCRIPTION
---
name: Diego Sotomayor
title: "fix: two-O2-tanks (#60 )"
---

## Summary

<!-- What does this PR do? Keep it to 1-2 sentences -->

Incorporated the second oxygen tank for the EVA into the frontend. 

<!-- Link the issue this PR resolves -->

Closes #60 

## What Changed

<!-- Brief description of the changes made -->

New prop in oxygen component called "primaryActive" set as True by default, but receives snapshot.eva.dcu.eva1.oxy as input for the EVA. When True the first tank is shown, when False the second tank is shown (accordingly with the Figma). Remaining time is also updated after the switch, and it's computed manually. 

## How to Test

<!-- Steps to verify the changes work as expected -->

1. Start the server, client, TSS and use the switch for the Oxygen in the TSS interface.
2.
3.

## Deployment Notes

<!-- Note any deployment requirements this PR introduces -->
<!-- Leave N/A if none -->

- [ ] Environment variables added or changed (if so document how to set up)
- [ ] Database migrations required
- [ ] Dependencies added or updated
- [ ] Config or infrastructure changes required

## Checklist

- [ ] PR title follows naming convention (`type: short description`)
- [ ] Merged `main` before opening PR
- [ ] Ran `make format`
- [ ] No unintended files or changes included
- [ ] PR is ready for admin review
